### PR TITLE
Fix TypeError in Search

### DIFF
--- a/Web/App.js
+++ b/Web/App.js
@@ -198,6 +198,7 @@ class App {
 		var allMatchReasons = {}
 
 		let itemMatch = (regex, item) => {
+			if (item == undefined) return false
 			if (regex.test(item.id)) return true
 			if (regex.test(DataRender.getItemDescription(item))) return true
 			return false


### PR DESCRIPTION
A TypeError in the ItemMatch function causes the search box to not work for me. This should stop regex from searching on undefined items.